### PR TITLE
Bugfix for medium sized files (2 to 4 GB)

### DIFF
--- a/LibTiff/Internal/Tiff_Read.cs
+++ b/LibTiff/Internal/Tiff_Read.cs
@@ -199,7 +199,7 @@ namespace BitMiracle.LibTiff.Classic
                 {
                     entry.tdir_count = (int)readInt(bytes, pos);
                     pos += sizeof (int);
-                    entry.tdir_offset = (ulong) readInt(bytes, pos);
+                    entry.tdir_offset = (ulong) (uint)readInt(bytes, pos);
                     pos += sizeof (int);
                 }
                 dir[i] = entry;


### PR DESCRIPTION
We found and fixed a bug that could occur when the tdir_offset is between int.max and uint.max.
The bug was caused by a missing cast to uint.