### PR TITLE
Short string tag bug

### DIFF
--- a/LibTiff/Internal/Tiff_DirRead.cs
+++ b/LibTiff/Internal/Tiff_DirRead.cs
@@ -580,7 +580,7 @@ namespace BitMiracle.LibTiff.Classic
                     if (count >= 5)
                         v[4] = (byte)((dir.tdir_offset >> 24) & 0xff);
 
-                    if (count == 4)
+                    if (count >= 4)
                         v[3] = (byte)((dir.tdir_offset >> 32) & 0xff);
 
                     if (count >= 3)
@@ -606,7 +606,7 @@ namespace BitMiracle.LibTiff.Classic
                     if (count >= 5)
                         v[4] = (byte)((dir.tdir_offset >> 32) & 0xff);
 
-                    if (count == 4)
+                    if (count >= 4)
                         v[3] = (byte)((dir.tdir_offset >> 24) & 0xff);
 
                     if (count >= 3)

--- a/LibTiff/Internal/Tiff_DirWrite.cs
+++ b/LibTiff/Internal/Tiff_DirWrite.cs
@@ -567,7 +567,7 @@ namespace BitMiracle.LibTiff.Classic
                                     if (dirB.tdir_count >= 3)
                                         dirB.tdir_offset |= ((ulong)cp[2] << 16);
 
-                                    if (dirB.tdir_count == 4)
+                                    if (dirB.tdir_count >= 4)
                                         dirB.tdir_offset |= ((ulong)cp[3] << 24);
 
                                     if (dirB.tdir_count >= 5)
@@ -576,7 +576,7 @@ namespace BitMiracle.LibTiff.Classic
                                     if (dirB.tdir_count >= 6)
                                         dirB.tdir_offset |= ((ulong)cp[5] << 40);
 
-                                    if (dirB.tdir_count == 7)
+                                    if (dirB.tdir_count >= 7)
                                         dirB.tdir_offset |= ((ulong)cp[6] << 48);
 
                                     if (dirB.tdir_count >= 8)
@@ -1311,7 +1311,7 @@ namespace BitMiracle.LibTiff.Classic
                     if (dir.tdir_count >= 3)
                         dir.tdir_offset |= ((ulong)cp[2] << 16);
 
-                    if (dir.tdir_count == 4)
+                    if (dir.tdir_count >= 4)
                         dir.tdir_offset |= ((ulong)cp[3] << 24);
 
                     if (dir.tdir_count >= 5)
@@ -1320,7 +1320,7 @@ namespace BitMiracle.LibTiff.Classic
                     if (dir.tdir_count >= 6)
                         dir.tdir_offset |= ((ulong)cp[5] << 40);
 
-                    if (dir.tdir_count == 7)
+                    if (dir.tdir_count >= 7)
                         dir.tdir_offset |= ((ulong)cp[6] << 48);
 
                     if (dir.tdir_count >= 8)


### PR DESCRIPTION
Fixes a bug where some short strings (5, 6, 8 chars) that should be
stored in the 8-byte BigTiff tag buffer have the 4th and 7th values 0'd
out.