### PR TITLE
Replace arbitrary int with named constant

### DIFF
--- a/LibTiff/Help/Samples/Using LibTiff.Net/Add custom TIFF tags to an existing TIFF image.aml
+++ b/LibTiff/Help/Samples/Using LibTiff.Net/Add custom TIFF tags to an existing TIFF image.aml
@@ -29,8 +29,9 @@ namespace BitMiracle.LibTiff.Samples
         {
             TiffFieldInfo[] tiffFieldInfo = 
             {
-                new TiffFieldInfo(TIFFTAG_GDAL_METADATA, -1, -1, TiffType.ASCII,
-                    FieldBit.Custom, true, false, &quot;GDALMetadata&quot;),
+                new TiffFieldInfo(TIFFTAG_GDAL_METADATA, TiffFieldInfo.Variable, 
+                    TiffFieldInfo.Variable, TiffType.ASCII, FieldBit.Custom, 
+                    true, false, &quot;GDALMetadata&quot;),
             };
 
             tif.MergeFieldInfo(tiffFieldInfo, tiffFieldInfo.Length);
@@ -88,8 +89,9 @@ Namespace BitMiracle.LibTiff.Samples
         Private Shared m_parentExtender As Tiff.TiffExtendProc
 
         Public Shared Sub TagExtender(tif As Tiff)
-            Dim tiffFieldInfo As TiffFieldInfo() = {New TiffFieldInfo(TIFFTAG_GDAL_METADATA, -1, -1, TiffType.ASCII, FieldBit.[Custom], True, _
-             False, &quot;GDALMetadata&quot;)}
+            Dim tiffFieldInfo As TiffFieldInfo() = {New TiffFieldInfo(TIFFTAG_GDAL_METADATA, _
+              TiffFieldInfo.Variable, TiffFieldInfo.Variable, TiffType.ASCII, FieldBit.[Custom], _
+              True, False, &quot;GDALMetadata&quot;)}
 
             tif.MergeFieldInfo(tiffFieldInfo, tiffFieldInfo.Length)
 

--- a/LibTiff/Help/Samples/Using LibTiff.Net/Read and write custom TIFF tags.aml
+++ b/LibTiff/Help/Samples/Using LibTiff.Net/Read and write custom TIFF tags.aml
@@ -34,7 +34,8 @@ namespace BitMiracle.LibTiff.Samples
         {
             TiffFieldInfo[] tiffFieldInfo = 
             {
-                new TiffFieldInfo(TIFFTAG_ASCIITAG, -1, -1, TiffType.ASCII, FieldBit.Custom, true, false, &quot;MyTag&quot;),
+                new TiffFieldInfo(TIFFTAG_ASCIITAG, TiffFieldInfo.Variable, TiffFieldInfo.Variable, 
+                      TiffType.ASCII, FieldBit.Custom, true, false, &quot;MyTag&quot;),
                 new TiffFieldInfo(TIFFTAG_SHORTTAG, 2, 2, TiffType.SHORT, FieldBit.Custom, false, true, &quot;ShortTag&quot;),
                 new TiffFieldInfo(TIFFTAG_LONGTAG, 2, 2, TiffType.LONG, FieldBit.Custom, false, true, &quot;LongTag&quot;),
                 new TiffFieldInfo(TIFFTAG_RATIONALTAG, 2, 2, TiffType.RATIONAL, FieldBit.Custom, false, true, &quot;RationalTag&quot;),
@@ -182,8 +183,9 @@ Namespace BitMiracle.LibTiff.Samples
         Private Shared m_parentExtender As Tiff.TiffExtendProc
 
         Public Shared Sub TagExtender(ByVal tif As Tiff)
-            Dim tiffFieldInfo As TiffFieldInfo() = {New TiffFieldInfo(TIFFTAG_ASCIITAG, -1, -1, TiffType.ASCII, FieldBit.[Custom], True, _
-             False, &quot;MyTag&quot;), New TiffFieldInfo(TIFFTAG_SHORTTAG, 2, 2, TiffType.[SHORT], FieldBit.[Custom], False, _
+            Dim tiffFieldInfo As TiffFieldInfo() = {New TiffFieldInfo(TIFFTAG_ASCIITAG, TiffFieldInfo.Variable, _
+             TiffFieldInfo.Variable, TiffType.ASCII, FieldBit.[Custom], True, False, &quot;MyTag&quot;), _
+             New TiffFieldInfo(TIFFTAG_SHORTTAG, 2, 2, TiffType.[SHORT], FieldBit.[Custom], False, _
              True, &quot;ShortTag&quot;), New TiffFieldInfo(TIFFTAG_LONGTAG, 2, 2, TiffType.[LONG], FieldBit.[Custom], False, _
              True, &quot;LongTag&quot;), New TiffFieldInfo(TIFFTAG_RATIONALTAG, 2, 2, TiffType.RATIONAL, FieldBit.[Custom], False, _
              True, &quot;RationalTag&quot;), New TiffFieldInfo(TIFFTAG_FLOATTAG, 2, 2, TiffType.FLOAT, FieldBit.[Custom], False, _


### PR DESCRIPTION
In definitions of custom tag fieldinfo'es, the arbitrary `-1` for `readCount` and `writeCount` has been replaced with the named constant `TiffFieldInfo.Variable`.  Note that I don't speak vb, so if the constant needs to be accessed by some other name (such as 'TiffFieldInfo.[Variable]'), you'll need to correct that separately or let me know in this push's comments (where I'll be happy to do so).