### PR TITLE
Remove Silverlight preprocessor check

### DIFF
--- a/LibTiff/Internal/Tiff_Internal.cs
+++ b/LibTiff/Internal/Tiff_Internal.cs
@@ -45,12 +45,7 @@ namespace BitMiracle.LibTiff.Classic
         /// </summary>
         internal const bool CHECK_JPEG_YCBCR_SUBSAMPLING = true;
 
-#if !SILVERLIGHT
         internal static readonly Encoding Latin1Encoding = Encoding.GetEncoding("Latin1");
-#else
-        // Encoding.GetEncoding("Latin1") is not supported in Silverlight. Will throw exceptions at runtime.
-        internal static readonly Enc28591 Latin1Encoding = new Enc28591();
-#endif
 
         internal enum PostDecodeMethodType
         {


### PR DESCRIPTION
It seems Silverlight was removed, so this is not needed anymore?