### PR TITLE
Read next IFD offset as uint not int for 32 bit tiff (already good fo…

### DIFF
--- a/LibTiff/Internal/Tiff_DirRead.cs
+++ b/LibTiff/Internal/Tiff_DirRead.cs
@@ -238,8 +238,8 @@ namespace BitMiracle.LibTiff.Classic
             }
             else
             {
-                int tempInt = 0;
-                readIntOK(out tempInt);
+                uint tempInt = 0;
+                readUIntOK(out tempInt);
                 nextdiroff = (ulong)tempInt;
             }
 

--- a/LibTiff/Internal/Tiff_DirRead.cs
+++ b/LibTiff/Internal/Tiff_DirRead.cs
@@ -238,9 +238,9 @@ namespace BitMiracle.LibTiff.Classic
             }
             else
             {
-                uint tempInt = 0;
-                readUIntOK(out tempInt);
-                nextdiroff = (ulong)tempInt;
+                uint tempUInt = 0;
+                readUIntOK(out tempUInt);
+                nextdiroff = (ulong)tempUInt;
             }
 
             if ((m_flags & TiffFlags.SWAB) == TiffFlags.SWAB)


### PR DESCRIPTION
…r bigtiff)

The IFD for "small"Tiff was being read into a temporary int32.
When the IFD offset was greater than int.max +1 this would represent a negative number, causing issues with large files with IFDs stored beyond 2 Gig.