### PR TITLE
Added the GDAL_NODATA tag

### DIFF
--- a/LibTiff/Enums/TiffTag.cs
+++ b/LibTiff/Enums/TiffTag.cs
@@ -1429,5 +1429,10 @@
         /// This tag is used to store all of the ASCII valued GeoKeys, referenced by the GeoKeyDirectoryTag. Used in interchangeable GeoTIFF files.
         /// </summary>
         GEOTIFF_GEOASCIIPARAMSTAG = 34737,
+
+        /// <summary>
+        /// This tag is used to store the band nodata value. Used in interchangeable GeoTIFF files.
+        /// </summary>
+        GDAL_NODATA = 42113,
     }
 }


### PR DESCRIPTION
This PR allows using the GDAL_NODATA tag in GeoTIFF files. It only adds the tag to the TiffTag enum, extended use of the tag will require registering the correct TiffFieldInfo.